### PR TITLE
revert +1 in dim max

### DIFF
--- a/domoticzApiHelper.js
+++ b/domoticzApiHelper.js
@@ -62,7 +62,7 @@ exports.sendDeviceCommand = async function (request, value){
 	//take care of MaxDimLevel if percentage
 	if(directive === "SetPercentage" && cookieInfos["MaxDimLevel"])
 	{
-		const proportionalValue = parseInt(value) * (parseInt(cookieInfos["MaxDimLevel"])+1) / 100;
+		const proportionalValue = parseInt(value) * (parseInt(cookieInfos["MaxDimLevel"])) / 100;
 		directiveValue = Math.round(proportionalValue);
 	}
 

--- a/domoticzApiHelper.js
+++ b/domoticzApiHelper.js
@@ -62,7 +62,7 @@ exports.sendDeviceCommand = async function (request, value){
 	//take care of MaxDimLevel if percentage
 	if(directive === "SetPercentage" && cookieInfos["MaxDimLevel"])
 	{
-		const proportionalValue = parseInt(value) * (parseInt(cookieInfos["MaxDimLevel"])) / 100;
+		const proportionalValue = parseInt(value) * parseInt(cookieInfos["MaxDimLevel"]) / 100;
 		directiveValue = Math.round(proportionalValue);
 	}
 

--- a/test/__tests__/test_sendCommands.js
+++ b/test/__tests__/test_sendCommands.js
@@ -116,7 +116,7 @@ test('SENDING SET BRIGHTNESS', async done => {
 
 test('SENDING TO DEVICE WITH MAXDIM', async done => {
     const data = await base_config.sendDeviceCommand(base_config.mockups.ALEXA_SETPERCENT_MAXDIM,73);
-    expect(data).toBe("?type=command&param=switchlight&idx=1503&switchcmd=Set%20Level&level=12");
+    expect(data).toBe("?type=command&param=switchlight&idx=1503&switchcmd=Set%20Level&level=11");
     done();
 });
 


### PR DESCRIPTION
Je ne me rappelle plus pourquoi le +1 avait été ajouté.
Suppression du coup car certains utilisateurs ont besoin que le % soit précis pour des interrupteurs qui basculent en fonction du % demandé.

Du coup pour 100 de max, si on laisse le +1, 50% revient à 51%

