### PR TITLE
Fix again white

### DIFF
--- a/config/domoticzCommands.js
+++ b/config/domoticzCommands.js
@@ -56,7 +56,7 @@ device_handler_command = (subType,value)=>({
 		"param" : SETCOLOR_PARAM,
 		"value" : (value
 					?  value.saturation == 0 
-					    ? 'brightness='+ (value.brightness*100) + '&color={"m":3,"t":0,"r":255,"g":255,"b":255,"cw":0,"ww":0}'
+					    ? 'brightness='+ (value.brightness*100) + '&color={"m":3,"t":0,"r":254,"g":254,"b":254,"cw":0,"ww":0}'
 					    : ("hue="+value.hue+"&brightness="+ (value.brightness*100)+"&iswhite=" + (value.saturation == 0 ? 'true':'false'))
 					: null),
 	},

--- a/test/__tests__/test_sendCommands.js
+++ b/test/__tests__/test_sendCommands.js
@@ -116,7 +116,7 @@ test('SENDING SET COLOR WHITE', async done => {
                 "brightness": 0.6524
             };
     const data = await base_config.sendDeviceCommand(base_config.mockups.ALEXA_SET_COLOR,HSLvalue);
-    expect(data).toBe("/json.htm?type=command&param=setcolbrightnessvalue&idx=37&brightness=65.24&color=%7B%22m%22:3,%22t%22:0,%22r%22:255,%22g%22:255,%22b%22:255,%22cw%22:0,%22ww%22:0%7D");
+    expect(data).toBe("/json.htm?type=command&param=setcolbrightnessvalue&idx=37&brightness=65.24&color=%7B%22m%22:3,%22t%22:0,%22r%22:254,%22g%22:254,%22b%22:254,%22cw%22:0,%22ww%22:0%7D");
     done();
 });
 


### PR DESCRIPTION
For some device (like rgbww), it's impossible to reach 255 lvl for all colors.
In fact, only the blue can reach this color.
So, sending a command by setting R/G/B to 255 will set the device color to B:255, G:254, R: 254.

The user would not be aware that the color is blue, but Alexa will display a "blue color" status instead of white.

This fix set colors to 254 to prevent this problem