### PR TITLE
ci: rename AWS secrets to canonical names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
       - run: yarn install --production
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_PREPROD_ACCESS_SECRET }}
-          aws-region: ${{ secrets.AWS_REGION_NAME }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - run: sh ./scripts/deploy.sh

--- a/docs/superpowers/plans/2026-05-02-circleci-to-github-actions.md
+++ b/docs/superpowers/plans/2026-05-02-circleci-to-github-actions.md
@@ -175,9 +175,9 @@ jobs:
       - run: yarn install --production
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_PREPROD_ACCESS_SECRET }}
-          aws-region: ${{ secrets.AWS_REGION_NAME }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - run: sh ./scripts/deploy.sh
 ```
 
@@ -215,6 +215,6 @@ Avant d'utiliser le workflow de déploiement, créer deux environnements dans **
 - `prod` : ajouter les reviewers requis
 
 Puis configurer les secrets dans **Settings → Secrets → Actions** :
-- `AWS_ACCESS_KEY`
-- `AWS_PREPROD_ACCESS_SECRET`
-- `AWS_REGION_NAME`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_DEFAULT_REGION`

--- a/docs/superpowers/specs/2026-05-02-circleci-to-github-actions-design.md
+++ b/docs/superpowers/specs/2026-05-02-circleci-to-github-actions-design.md
@@ -40,9 +40,9 @@ Le projet utilise CircleCI pour les tests et les déploiements vers AWS Lambda. 
 
 | Nom | Usage |
 |-----|-------|
-| `AWS_ACCESS_KEY` | Clé d'accès AWS |
-| `AWS_PREPROD_ACCESS_SECRET` | Secret AWS (utilisé pour preprod et prod) |
-| `AWS_REGION_NAME` | Région AWS |
+| `AWS_ACCESS_KEY_ID` | Clé d'accès AWS |
+| `AWS_SECRET_ACCESS_KEY` | Secret AWS (utilisé pour preprod et prod) |
+| `AWS_DEFAULT_REGION` | Région AWS |
 
 ### Variables par environnement
 


### PR DESCRIPTION
## Summary

Aligne les secrets AWS du workflow `deploy.yml` sur la convention de nommage standard AWS.

| Avant | Après |
|---|---|
| `AWS_ACCESS_KEY` | `AWS_ACCESS_KEY_ID` |
| `AWS_PREPROD_ACCESS_SECRET` | `AWS_SECRET_ACCESS_KEY` |
| `AWS_REGION_NAME` | `AWS_DEFAULT_REGION` |

Le nom historique `AWS_PREPROD_ACCESS_SECRET` était hérité de l'ancienne configuration CircleCI ; il sert pour preprod *et* prod malgré le préfixe trompeur. Les nouveaux noms suivent les variables d'environnement officielles AWS.

## Action requise après merge

Re-créer les 3 secrets avec les nouveaux noms dans **Settings → Secrets and variables → Actions** (ou par environnement si vous voulez scoper preprod/prod séparément).

## Fichiers modifiés

- `.github/workflows/deploy.yml` (le seul changement fonctionnel)
- `docs/superpowers/specs/2026-05-02-circleci-to-github-actions-design.md` (cohérence)
- `docs/superpowers/plans/2026-05-02-circleci-to-github-actions.md` (cohérence)

## Test plan

- [ ] CI verte
- [ ] Après merge : créer les secrets avec les nouveaux noms et déclencher un déploiement preprod manuel pour valider

🤖 Generated with [Claude Code](https://claude.com/claude-code)