### PR TITLE
feat(terraform): manage Lambda handler / layer / env vars in Terraform

### DIFF
--- a/terraform/.envrc.example
+++ b/terraform/.envrc.example
@@ -21,3 +21,60 @@ export TF_VAR_nr_region="EU"
 # Bootstrap-specific:
 export TF_VAR_bucket_name="alhau-tfstate"
 export TF_VAR_region="eu-west-1"
+
+# --- terraform/lambda-config/ module --------------------------------
+# Manages the Lambda IAM roles, handler/layer/runtime config and the
+# full environment variable map. See terraform/lambda-config/README.md.
+
+# NR Lambda license key (a.k.a. Ingest key). EU keys start with eu01xx.
+# Find at https://one.eu.newrelic.com/api-keys → type "License key".
+export TF_VAR_nr_license_key="eu01xx..."
+
+# Forward CloudWatch Lambda logs to New Relic (true = ingested in NR Log).
+# Set to false on the free tier if log ingest grows too fast.
+export TF_VAR_nr_extension_send_function_logs=true
+
+# How long the NR Lambda extension waits for agent payloads after the
+# handler returns. Default 30s — covers slow Domoticz requests without
+# delaying the user-visible Alexa response. Override only if needed.
+# export TF_VAR_nr_data_collection_timeout="30s"
+
+# Per-environment Lambda config (JSON-encoded HCL object).
+# env_vars must contain the FULL current map — anything missing is
+# REMOVED from the live function on apply. Generate from existing
+# Lambda with:
+#   aws lambda get-function-configuration --function-name alhau_preprod \
+#     --region eu-west-1 --query 'Environment.Variables' --output json
+# (Strip out NEW_RELIC_LICENSE_KEY / ACCOUNT_ID / LAMBDA_HANDLER /
+#  APM_LAMBDA_MODE / EXTENSION_SEND_FUNCTION_LOGS / DATA_COLLECTION_TIMEOUT
+#  — those are managed by main.tf via the dedicated TF vars above.)
+export TF_VAR_preprod='{
+  "function_name": "alhau_preprod",
+  "iam_role_name": "alhau_preprod-execution",
+  "env_vars": {
+    "INSTANCE_NAME": "PREPROD",
+    "PROD_MODE": "true",
+    "CRYPTOPASS": "...",
+    "MYSQL_ADDON_HOST": "...",
+    "MYSQL_ADDON_PORT": "...",
+    "MYSQL_ADDON_USER": "...",
+    "MYSQL_ADDON_PASSWORD": "...",
+    "MYSQL_ADDON_DB": "...",
+    "DOMOTICZ_API_HOST": "...",
+    "DOMOTICZ_API_PORT": "...",
+    "DOMOTICZ_API_LOGIN": "...",
+    "DOMOTICZ_API_PASSWORD": "...",
+    "METRICS_HOST": "...",
+    "METRICS_PORT": "...",
+    "METRICS_UDP_PORT": "..."
+  }
+}'
+
+export TF_VAR_prod='{
+  "function_name": "ludohomekit",
+  "iam_role_name": "ludohomekit-execution",
+  "env_vars": {
+    "INSTANCE_NAME": "prod",
+    "PROD_MODE": "true"
+  }
+}'

--- a/terraform/.envrc.example
+++ b/terraform/.envrc.example
@@ -39,6 +39,13 @@ export TF_VAR_nr_extension_send_function_logs=true
 # delaying the user-visible Alexa response. Override only if needed.
 # export TF_VAR_nr_data_collection_timeout="30s"
 
+# Name of the IAM role shared by both Lambdas (preprod + prod).
+# Get the existing one with:
+#   aws lambda get-function-configuration --function-name alhau_preprod \
+#     --region eu-west-1 --query 'Role' --output text
+# and strip the ARN prefix (everything before/including the last `/`).
+export TF_VAR_shared_iam_role_name="..."
+
 # Per-environment Lambda config (JSON-encoded HCL object).
 # env_vars must contain the FULL current map — anything missing is
 # REMOVED from the live function on apply. Generate from existing
@@ -50,7 +57,6 @@ export TF_VAR_nr_extension_send_function_logs=true
 #  — those are managed by main.tf via the dedicated TF vars above.)
 export TF_VAR_preprod='{
   "function_name": "alhau_preprod",
-  "iam_role_name": "alhau_preprod-execution",
   "env_vars": {
     "INSTANCE_NAME": "PREPROD",
     "PROD_MODE": "true",
@@ -72,7 +78,6 @@ export TF_VAR_preprod='{
 
 export TF_VAR_prod='{
   "function_name": "ludohomekit",
-  "iam_role_name": "ludohomekit-execution",
   "env_vars": {
     "INSTANCE_NAME": "prod",
     "PROD_MODE": "true"

--- a/terraform/.envrc.example
+++ b/terraform/.envrc.example
@@ -39,6 +39,11 @@ export TF_VAR_nr_extension_send_function_logs=true
 # delaying the user-visible Alexa response. Override only if needed.
 # export TF_VAR_nr_data_collection_timeout="30s"
 
+# Per-invocation timeout and memory for both Lambdas. Defaults 30s and
+# 128 MB. Override here if you tuned the live Lambdas differently.
+# export TF_VAR_lambda_timeout=30
+# export TF_VAR_lambda_memory_size=128
+
 # Name of the IAM role shared by both Lambdas (preprod + prod).
 # Get the existing one with:
 #   aws lambda get-function-configuration --function-name alhau_preprod \

--- a/terraform/lambda-config/README.md
+++ b/terraform/lambda-config/README.md
@@ -1,88 +1,144 @@
 # Terraform — Lambda runtime configuration
 
-Manages the **runtime config** of both Lambdas (`alhau_preprod` / `ludohomekit`):
-handler, layers, environment variables. Everything we previously set
-manually in the AWS console.
+Manages the **IAM execution role + runtime config** of both Lambdas
+(`alhau_preprod` / `ludohomekit`): role, handler, runtime, layers,
+environment variables. Replaces what we previously set by hand in the
+AWS console.
 
 The **code zip** stays managed by `scripts/deploy.sh` (which calls
 `aws lambda update-function-code`). Terraform points at a placeholder
-and ignores all code-related attributes via `lifecycle.ignore_changes`.
+zip and ignores all code-related attributes via
+`lifecycle.ignore_changes`.
 
-## What Terraform does (and doesn't do) here
+## What Terraform owns (and doesn't)
 
 | Owned by Terraform | Owned elsewhere |
 |---|---|
-| `handler` = `newrelic-lambda-wrapper.handler` | Code zip (deploy.sh) |
-| `runtime` = `nodejs24.x` | IAM role + its policies |
-| `layers` (NR Lambda Layer) | Triggers (Alexa skill) |
-| `environment.variables` (FULL map: app + NR) | Destinations / DLQ |
+| IAM execution role + basic Lambda policy | Code zip (`deploy.sh`) |
+| `handler` = `newrelic-lambda-wrapper.handler` | Triggers (Alexa skill) |
+| `runtime` = `nodejs24.x` | Destinations / DLQ |
+| `layers` (NR Lambda Layer) | |
+| `environment.variables` (full map: app + NR) | |
 
 ## Prerequisites
 
 - Terraform >= 1.10
-- `terraform/.envrc` sourced with `AWS_*` and `NEW_RELIC_*` env vars
-- The two Lambdas already exist on AWS — Terraform will **import** them,
-  not create from scratch.
+- `terraform/.envrc` sourced with `AWS_*` + `TF_VAR_nr_license_key` +
+  `TF_VAR_nr_account_id`
+- AWS credentials with IAM + Lambda permissions
 
-## First-time bootstrap (one-shot)
+## Path A — From-scratch deployment
 
-### 1. Capture current values from AWS
+For a fresh AWS account or after recreating everything from zero. The
+order matters because each step depends on the previous.
 
-For each function (`alhau_preprod`, `ludohomekit`):
+### 1. Create the Terraform state bucket (one-shot per AWS account)
 
 ```bash
-# Role ARN
-aws lambda get-function-configuration \
-  --function-name alhau_preprod --region eu-west-1 \
-  --query 'Role' --output text
-
-# Current env vars (use as basis for `env_vars` in tfvars)
-aws lambda get-function-configuration \
-  --function-name alhau_preprod --region eu-west-1 \
-  --query 'Environment.Variables' --output json
+cd terraform/bootstrap
+terraform init
+terraform apply        # creates the alhau-tfstate S3 bucket
 ```
 
-Repeat with `--function-name ludohomekit` for prod.
-
-### 2. Fill in `terraform.tfvars`
+### 2. Fill in tfvars
 
 ```bash
 cd terraform/lambda-config
 cp terraform.tfvars.example terraform.tfvars
-# Edit terraform.tfvars: paste role_arn and env_vars from step 1
+# Edit terraform.tfvars: pick role names, paste env_vars
 ```
 
-⚠️ **Important** — `env_vars` must contain **every** existing app env
-var (DOMOTICZ_*, MYSQL_*, CRYPTOPASS, etc.). Any var present on the
-live function but missing from `env_vars` will be **deleted** at
-`terraform apply` time. The NR_* env vars are managed automatically
-via `main.tf` and should NOT appear in `env_vars`.
-
-The `terraform.tfvars` file contains secrets (DB passwords, etc.) —
-it is gitignored. Don't commit it.
-
-### 3. Set the NR license key via env var
+### 3. Set the NR license key
 
 ```bash
 # Add to terraform/.envrc (gitignored):
 export TF_VAR_nr_license_key="eu01xxYOURKEYHERE"
 ```
 
-This keeps the license key out of `terraform.tfvars` entirely.
-
-### 4. Initialize and import
+### 4. Apply
 
 ```bash
 terraform init
+terraform apply
+```
+
+Terraform creates:
+- Both IAM execution roles (`alhau_preprod-execution`, `ludohomekit-execution`)
+- The basic Lambda execution policy attachments (for CloudWatch Logs)
+- Both Lambda functions with handler/runtime/layers/env vars set
+  (using a tiny placeholder zip — real code comes next)
+
+### 5. Deploy the real function code
+
+```bash
+cd ../..
+sh scripts/deploy.sh          # or via the GitHub Actions Deploy workflow
+```
+
+`deploy.sh` updates the function code in place; Terraform's
+`lifecycle.ignore_changes` keeps it from fighting back.
+
+### 6. Create the New Relic dashboard
+
+```bash
+cd terraform/dashboard
+terraform init
+terraform apply
+```
+
+You now have a fully reproducible setup from a vanilla AWS account.
+
+## Path B — Adopt existing functions (recommended for current users)
+
+Same module, different flow: Terraform takes over an already-existing
+Lambda + role instead of creating them.
+
+### 1. Capture current state from AWS
+
+```bash
+# Function names + roles (note the role NAME at the end, not the ARN)
+aws lambda get-function-configuration --function-name alhau_preprod \
+  --region eu-west-1 --query 'Role' --output text
+# → arn:aws:iam::xxxxx:role/service-role/alhau_preprod-role-abc123
+#                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ this part
+
+# Current env vars (full map)
+aws lambda get-function-configuration --function-name alhau_preprod \
+  --region eu-west-1 --query 'Environment.Variables' --output json
+```
+
+Repeat for `ludohomekit`.
+
+### 2. Fill in `terraform.tfvars`
+
+Set `iam_role_name` to the existing role's **name** (not the full ARN),
+and paste the env vars into the `env_vars` map. ⚠️ **The map must be
+COMPLETE** — anything missing from `env_vars` will be deleted from the
+live function on apply. The NR_* env vars are managed automatically
+via `main.tf` and should NOT appear in `env_vars`.
+
+### 3. Initialize and import
+
+```bash
+cd terraform/lambda-config
+terraform init
+
+# Import existing roles (use the role NAME you extracted above)
+terraform import aws_iam_role.preprod alhau_preprod-role-abc123
+terraform import aws_iam_role.prod    ludohomekit-role-def456
+
+# Then the policy attachments (use <role-name>/<policy-arn>)
+terraform import aws_iam_role_policy_attachment.preprod_basic_execution \
+  alhau_preprod-role-abc123/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+terraform import aws_iam_role_policy_attachment.prod_basic_execution \
+  ludohomekit-role-def456/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+# Finally the functions themselves
 terraform import aws_lambda_function.preprod alhau_preprod
 terraform import aws_lambda_function.prod    ludohomekit
 ```
 
-`terraform import` brings the existing AWS state into the Terraform
-state file. After this, Terraform knows the functions exist; the next
-plan will show diffs only for what's actually different.
-
-### 5. Plan and review
+### 4. Plan and review carefully
 
 ```bash
 terraform plan
@@ -91,45 +147,48 @@ terraform plan
 Expected diffs on first plan:
 
 - `layers` add (if the NR layer wasn't already attached)
-- `environment.variables` add (`NEW_RELIC_LAMBDA_HANDLER`,
-  `NEW_RELIC_APM_LAMBDA_MODE`, etc. that we manage)
-- `handler` change to `newrelic-lambda-wrapper.handler` (if not
-  already set)
+- `environment.variables` add (NEW_RELIC_* values managed by `main.tf`)
+- `handler` change to `newrelic-lambda-wrapper.handler` (if not already
+  set)
+- Possibly assume_role_policy alignment if the imported trust policy
+  differs from the canonical one in `iam.tf`
 
-If you see a diff that would remove an env var you actually need
-(e.g., `MYSQL_ADDON_PASSWORD`), it means your `env_vars` map is
-incomplete. Re-run the capture in step 1, update tfvars, re-plan.
+If you see a diff that removes an env var you actually need, your
+`env_vars` map is incomplete — fix the tfvars and re-plan.
 
-### 6. Apply
+If the existing IAM role has additional policies attached (beyond
+basic execution), the import won't see them. Add corresponding
+`aws_iam_role_policy_attachment` resources to `iam.tf` to keep them
+managed.
+
+### 5. Apply
 
 ```bash
 terraform apply
 ```
 
-After apply, the runtime config is reproducible. Next time you bump
-the NR layer version or change an env var, edit the .tf or tfvars,
-re-plan, re-apply.
+## Day-to-day operations
 
-## Day-to-day
-
-- **Deploy code only** → `scripts/deploy.sh` (existing workflow). Touches
-  the zip; Terraform ignores it via `lifecycle.ignore_changes`.
-- **Update layer version** → bump the default in `variables.tf` or set
-  `TF_VAR_nr_lambda_layer_arn`, then `terraform apply`.
-- **Add/change app env var** → edit `terraform.tfvars`, `terraform apply`.
-- **Add NR-managed env var** → edit `main.tf` locals.
+- **Deploy code only** → `scripts/deploy.sh` (or GitHub Actions Deploy
+  workflow). Terraform ignores it via `lifecycle.ignore_changes`.
+- **Bump NR layer version** → edit `nr_lambda_layer_arn` default in
+  `variables.tf` or override via `TF_VAR_nr_lambda_layer_arn`, then
+  `terraform apply`.
+- **Change an env var** → edit `terraform.tfvars`, `terraform apply`.
+- **Add an NR-managed env var** → edit `main.tf` `local.nr_env_vars_base`.
+- **Add a Lambda permission** → add an `aws_iam_role_policy` or
+  `aws_iam_role_policy_attachment` in `iam.tf`.
 
 ## Caveats
 
 - **Drift**: if someone changes the live function via the AWS console
   (e.g., adds an env var manually), the next `terraform plan` will
-  show that as drift and propose to remove it. Either update tfvars to
-  match, or revert the manual change.
-- **Code deploys racing apply**: `deploy.sh` and `terraform apply`
-  both modify the function, but they touch disjoint attributes
-  (code vs config). They can run in any order without conflict.
-- **First-time apply may report `last_modified` changes**: harmless,
-  Terraform is just refreshing the timestamp in state.
+  show that as drift and propose to remove it. Either update tfvars
+  to match, or revert the manual change.
+- **Code deploys vs `terraform apply`**: both run safely in any order
+  because they touch disjoint Lambda attributes (code vs config).
+- **First `apply` after import** may report a `last_modified`
+  change: harmless, Terraform is just refreshing the state timestamp.
 
 ## Architecture
 
@@ -137,9 +196,9 @@ re-plan, re-apply.
 terraform/
 ├── bootstrap/           # local state — creates the S3 bucket
 ├── dashboard/           # S3-backed — NR dashboard
-└── lambda-config/       # S3-backed — Lambda handler/layers/env vars  ← you are here
+└── lambda-config/       # S3-backed — IAM role + Lambda runtime config  ← you are here
 ```
 
 Both `dashboard/` and `lambda-config/` use the same S3 bucket
-(`alhau-tfstate`) with distinct keys, so they never clobber each
-other's state.
+(`alhau-tfstate`) under distinct state keys, so they never clobber
+each other.

--- a/terraform/lambda-config/README.md
+++ b/terraform/lambda-config/README.md
@@ -1,0 +1,145 @@
+# Terraform — Lambda runtime configuration
+
+Manages the **runtime config** of both Lambdas (`alhau_preprod` / `ludohomekit`):
+handler, layers, environment variables. Everything we previously set
+manually in the AWS console.
+
+The **code zip** stays managed by `scripts/deploy.sh` (which calls
+`aws lambda update-function-code`). Terraform points at a placeholder
+and ignores all code-related attributes via `lifecycle.ignore_changes`.
+
+## What Terraform does (and doesn't do) here
+
+| Owned by Terraform | Owned elsewhere |
+|---|---|
+| `handler` = `newrelic-lambda-wrapper.handler` | Code zip (deploy.sh) |
+| `runtime` = `nodejs24.x` | IAM role + its policies |
+| `layers` (NR Lambda Layer) | Triggers (Alexa skill) |
+| `environment.variables` (FULL map: app + NR) | Destinations / DLQ |
+
+## Prerequisites
+
+- Terraform >= 1.10
+- `terraform/.envrc` sourced with `AWS_*` and `NEW_RELIC_*` env vars
+- The two Lambdas already exist on AWS — Terraform will **import** them,
+  not create from scratch.
+
+## First-time bootstrap (one-shot)
+
+### 1. Capture current values from AWS
+
+For each function (`alhau_preprod`, `ludohomekit`):
+
+```bash
+# Role ARN
+aws lambda get-function-configuration \
+  --function-name alhau_preprod --region eu-west-1 \
+  --query 'Role' --output text
+
+# Current env vars (use as basis for `env_vars` in tfvars)
+aws lambda get-function-configuration \
+  --function-name alhau_preprod --region eu-west-1 \
+  --query 'Environment.Variables' --output json
+```
+
+Repeat with `--function-name ludohomekit` for prod.
+
+### 2. Fill in `terraform.tfvars`
+
+```bash
+cd terraform/lambda-config
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars: paste role_arn and env_vars from step 1
+```
+
+⚠️ **Important** — `env_vars` must contain **every** existing app env
+var (DOMOTICZ_*, MYSQL_*, CRYPTOPASS, etc.). Any var present on the
+live function but missing from `env_vars` will be **deleted** at
+`terraform apply` time. The NR_* env vars are managed automatically
+via `main.tf` and should NOT appear in `env_vars`.
+
+The `terraform.tfvars` file contains secrets (DB passwords, etc.) —
+it is gitignored. Don't commit it.
+
+### 3. Set the NR license key via env var
+
+```bash
+# Add to terraform/.envrc (gitignored):
+export TF_VAR_nr_license_key="eu01xxYOURKEYHERE"
+```
+
+This keeps the license key out of `terraform.tfvars` entirely.
+
+### 4. Initialize and import
+
+```bash
+terraform init
+terraform import aws_lambda_function.preprod alhau_preprod
+terraform import aws_lambda_function.prod    ludohomekit
+```
+
+`terraform import` brings the existing AWS state into the Terraform
+state file. After this, Terraform knows the functions exist; the next
+plan will show diffs only for what's actually different.
+
+### 5. Plan and review
+
+```bash
+terraform plan
+```
+
+Expected diffs on first plan:
+
+- `layers` add (if the NR layer wasn't already attached)
+- `environment.variables` add (`NEW_RELIC_LAMBDA_HANDLER`,
+  `NEW_RELIC_APM_LAMBDA_MODE`, etc. that we manage)
+- `handler` change to `newrelic-lambda-wrapper.handler` (if not
+  already set)
+
+If you see a diff that would remove an env var you actually need
+(e.g., `MYSQL_ADDON_PASSWORD`), it means your `env_vars` map is
+incomplete. Re-run the capture in step 1, update tfvars, re-plan.
+
+### 6. Apply
+
+```bash
+terraform apply
+```
+
+After apply, the runtime config is reproducible. Next time you bump
+the NR layer version or change an env var, edit the .tf or tfvars,
+re-plan, re-apply.
+
+## Day-to-day
+
+- **Deploy code only** → `scripts/deploy.sh` (existing workflow). Touches
+  the zip; Terraform ignores it via `lifecycle.ignore_changes`.
+- **Update layer version** → bump the default in `variables.tf` or set
+  `TF_VAR_nr_lambda_layer_arn`, then `terraform apply`.
+- **Add/change app env var** → edit `terraform.tfvars`, `terraform apply`.
+- **Add NR-managed env var** → edit `main.tf` locals.
+
+## Caveats
+
+- **Drift**: if someone changes the live function via the AWS console
+  (e.g., adds an env var manually), the next `terraform plan` will
+  show that as drift and propose to remove it. Either update tfvars to
+  match, or revert the manual change.
+- **Code deploys racing apply**: `deploy.sh` and `terraform apply`
+  both modify the function, but they touch disjoint attributes
+  (code vs config). They can run in any order without conflict.
+- **First-time apply may report `last_modified` changes**: harmless,
+  Terraform is just refreshing the timestamp in state.
+
+## Architecture
+
+```
+terraform/
+├── bootstrap/           # local state — creates the S3 bucket
+├── dashboard/           # S3-backed — NR dashboard
+└── lambda-config/       # S3-backed — Lambda handler/layers/env vars  ← you are here
+```
+
+Both `dashboard/` and `lambda-config/` use the same S3 bucket
+(`alhau-tfstate`) with distinct keys, so they never clobber each
+other's state.

--- a/terraform/lambda-config/README.md
+++ b/terraform/lambda-config/README.md
@@ -63,10 +63,11 @@ terraform apply
 ```
 
 Terraform creates:
-- Both IAM execution roles (`alhau_preprod-execution`, `ludohomekit-execution`)
-- The basic Lambda execution policy attachments (for CloudWatch Logs)
-- Both Lambda functions with handler/runtime/layers/env vars set
-  (using a tiny placeholder zip — real code comes next)
+- One shared IAM execution role (named per `shared_iam_role_name`)
+- The basic Lambda execution policy attached to it (for CloudWatch Logs)
+- Both Lambda functions with handler/runtime/layers/env vars set,
+  pointing to the shared role (using a tiny placeholder zip — real code
+  comes next)
 
 ### 5. Deploy the real function code
 
@@ -111,29 +112,30 @@ Repeat for `ludohomekit`.
 
 ### 2. Fill in `terraform.tfvars`
 
-Set `iam_role_name` to the existing role's **name** (not the full ARN),
-and paste the env vars into the `env_vars` map. ⚠️ **The map must be
-COMPLETE** — anything missing from `env_vars` will be deleted from the
-live function on apply. The NR_* env vars are managed automatically
-via `main.tf` and should NOT appear in `env_vars`.
+Set `shared_iam_role_name` to the existing role's **name** (not the
+full ARN — strip everything before/including the last `/`), and paste
+the env vars into each `env_vars` map. ⚠️ **The map must be COMPLETE** —
+anything missing from `env_vars` will be deleted from the live function
+on apply. The NR_* env vars are managed automatically via `main.tf` and
+should NOT appear in `env_vars`.
 
 ### 3. Initialize and import
+
+Because preprod and prod share the same IAM role, the role is imported
+ONCE.
 
 ```bash
 cd terraform/lambda-config
 terraform init
 
-# Import existing roles (use the role NAME you extracted above)
-terraform import aws_iam_role.preprod alhau_preprod-role-abc123
-terraform import aws_iam_role.prod    ludohomekit-role-def456
+# Import the shared role (use the role NAME, not ARN)
+terraform import aws_iam_role.shared <existing-role-name>
 
-# Then the policy attachments (use <role-name>/<policy-arn>)
-terraform import aws_iam_role_policy_attachment.preprod_basic_execution \
-  alhau_preprod-role-abc123/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-terraform import aws_iam_role_policy_attachment.prod_basic_execution \
-  ludohomekit-role-def456/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+# Import the policy attachment (<role-name>/<policy-arn>)
+terraform import aws_iam_role_policy_attachment.shared_basic_execution \
+  <existing-role-name>/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 
-# Finally the functions themselves
+# Import each function
 terraform import aws_lambda_function.preprod alhau_preprod
 terraform import aws_lambda_function.prod    ludohomekit
 ```

--- a/terraform/lambda-config/backend.tf
+++ b/terraform/lambda-config/backend.tf
@@ -1,0 +1,12 @@
+# Remote state stored in the same S3 bucket as the dashboard module's
+# state, under a distinct key so the two root modules don't clobber
+# each other. The bucket itself is created by terraform/bootstrap/.
+terraform {
+  backend "s3" {
+    bucket       = "alhau-tfstate"
+    key          = "lambda-config/terraform.tfstate"
+    region       = "eu-west-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/terraform/lambda-config/functions.tf
+++ b/terraform/lambda-config/functions.tf
@@ -23,7 +23,7 @@
 
 resource "aws_lambda_function" "preprod" {
   function_name = var.preprod.function_name
-  role          = aws_iam_role.preprod.arn
+  role          = aws_iam_role.shared.arn
   runtime       = "nodejs24.x"
   handler       = "newrelic-lambda-wrapper.handler"
 
@@ -50,7 +50,7 @@ resource "aws_lambda_function" "preprod" {
 
 resource "aws_lambda_function" "prod" {
   function_name = var.prod.function_name
-  role          = aws_iam_role.prod.arn
+  role          = aws_iam_role.shared.arn
   runtime       = "nodejs24.x"
   handler       = "newrelic-lambda-wrapper.handler"
 

--- a/terraform/lambda-config/functions.tf
+++ b/terraform/lambda-config/functions.tf
@@ -23,7 +23,7 @@
 
 resource "aws_lambda_function" "preprod" {
   function_name = var.preprod.function_name
-  role          = var.preprod.role_arn
+  role          = aws_iam_role.preprod.arn
   runtime       = "nodejs24.x"
   handler       = "newrelic-lambda-wrapper.handler"
 
@@ -50,7 +50,7 @@ resource "aws_lambda_function" "preprod" {
 
 resource "aws_lambda_function" "prod" {
   function_name = var.prod.function_name
-  role          = var.prod.role_arn
+  role          = aws_iam_role.prod.arn
   runtime       = "nodejs24.x"
   handler       = "newrelic-lambda-wrapper.handler"
 

--- a/terraform/lambda-config/functions.tf
+++ b/terraform/lambda-config/functions.tf
@@ -26,6 +26,8 @@ resource "aws_lambda_function" "preprod" {
   role          = aws_iam_role.shared.arn
   runtime       = "nodejs24.x"
   handler       = "newrelic-lambda-wrapper.handler"
+  timeout       = var.lambda_timeout
+  memory_size   = var.lambda_memory_size
 
   filename         = data.archive_file.placeholder.output_path
   source_code_hash = data.archive_file.placeholder.output_base64sha256
@@ -52,6 +54,8 @@ resource "aws_lambda_function" "prod" {
   role          = aws_iam_role.shared.arn
   runtime       = "nodejs24.x"
   handler       = "newrelic-lambda-wrapper.handler"
+  timeout       = var.lambda_timeout
+  memory_size   = var.lambda_memory_size
 
   filename         = data.archive_file.placeholder.output_path
   source_code_hash = data.archive_file.placeholder.output_base64sha256

--- a/terraform/lambda-config/functions.tf
+++ b/terraform/lambda-config/functions.tf
@@ -1,0 +1,76 @@
+# Lambda runtime configuration for both env (preprod + prod).
+#
+# What Terraform owns here:
+#   - handler          (newrelic-lambda-wrapper.handler — the NR layer wrapper)
+#   - runtime          (nodejs24.x)
+#   - layers           (the NR Lambda Layer)
+#   - environment      (full merged map of app vars + NR vars)
+#
+# What Terraform does NOT own:
+#   - The code zip itself — managed by scripts/deploy.sh which calls
+#     `aws lambda update-function-code`. We point at a placeholder zip
+#     and ignore all code-related attributes via lifecycle.
+#   - The IAM role policy — Terraform references the existing role ARN
+#     and never modifies its attached policies.
+#
+# Before the first `terraform apply`, you MUST import each function:
+#
+#   terraform import aws_lambda_function.preprod alhau_preprod
+#   terraform import aws_lambda_function.prod    ludohomekit
+#
+# This brings the existing AWS state into Terraform without recreating
+# the functions. See README.md for the full bootstrapping sequence.
+
+resource "aws_lambda_function" "preprod" {
+  function_name = var.preprod.function_name
+  role          = var.preprod.role_arn
+  runtime       = "nodejs24.x"
+  handler       = "newrelic-lambda-wrapper.handler"
+
+  filename         = data.archive_file.placeholder.output_path
+  source_code_hash = data.archive_file.placeholder.output_base64sha256
+
+  layers = [var.nr_lambda_layer_arn]
+
+  environment {
+    variables = merge(var.preprod.env_vars, local.nr_env_vars)
+  }
+
+  lifecycle {
+    ignore_changes = [
+      filename,
+      s3_bucket,
+      s3_key,
+      s3_object_version,
+      source_code_hash,
+      last_modified,
+    ]
+  }
+}
+
+resource "aws_lambda_function" "prod" {
+  function_name = var.prod.function_name
+  role          = var.prod.role_arn
+  runtime       = "nodejs24.x"
+  handler       = "newrelic-lambda-wrapper.handler"
+
+  filename         = data.archive_file.placeholder.output_path
+  source_code_hash = data.archive_file.placeholder.output_base64sha256
+
+  layers = [var.nr_lambda_layer_arn]
+
+  environment {
+    variables = merge(var.prod.env_vars, local.nr_env_vars)
+  }
+
+  lifecycle {
+    ignore_changes = [
+      filename,
+      s3_bucket,
+      s3_key,
+      s3_object_version,
+      source_code_hash,
+      last_modified,
+    ]
+  }
+}

--- a/terraform/lambda-config/functions.tf
+++ b/terraform/lambda-config/functions.tf
@@ -43,7 +43,6 @@ resource "aws_lambda_function" "preprod" {
       s3_key,
       s3_object_version,
       source_code_hash,
-      last_modified,
     ]
   }
 }
@@ -70,7 +69,6 @@ resource "aws_lambda_function" "prod" {
       s3_key,
       s3_object_version,
       source_code_hash,
-      last_modified,
     ]
   }
 }

--- a/terraform/lambda-config/iam.tf
+++ b/terraform/lambda-config/iam.tf
@@ -1,19 +1,31 @@
-# IAM execution roles for the Lambdas.
+# IAM execution role shared by both Lambdas.
+#
+# Both alhau_preprod and ludohomekit use the SAME execution role.
+# We model that with a single aws_iam_role resource here and reference
+# it from both aws_lambda_function blocks in functions.tf.
 #
 # The Lambda code only needs the basic execution role (CloudWatch Logs).
 # All external calls are HTTPS (to Domoticz) or MySQL over TCP — neither
 # requires AWS service permissions. If you later add S3/DynamoDB/etc.
 # access, attach additional policies here.
 #
-# For from-scratch deployment, `terraform apply` creates these roles.
-# For an existing setup, import them before apply:
+# For from-scratch deployment, `terraform apply` creates this role.
+# For an existing setup, import it before apply:
 #
-#   terraform import aws_iam_role.preprod <existing-role-name>
-#   terraform import aws_iam_role.prod    <existing-role-name>
+#   terraform import aws_iam_role.shared <existing-role-name>
+#   terraform import aws_iam_role_policy_attachment.shared_basic_execution \
+#     <existing-role-name>/arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 #
-# (Find existing role names with `aws lambda get-function-configuration
-#  --function-name <fn> --query 'Role' --output text` and strip the ARN
-#  prefix to keep just the role name.)
+# Find the existing role name with:
+#   aws lambda get-function-configuration --function-name <fn> \
+#     --query 'Role' --output text
+# and strip the ARN prefix to keep just the role name.
+#
+# ⚠️ If the existing role has policies attached beyond the basic
+# execution role (common when the role was created by AWS Serverless
+# Application Repository or similar), you'll need to add a matching
+# aws_iam_role_policy_attachment for each one, otherwise `terraform
+# apply` will detach them from the role. See README → "Adopt existing".
 
 data "aws_iam_policy_document" "lambda_assume_role" {
   statement {
@@ -26,22 +38,12 @@ data "aws_iam_policy_document" "lambda_assume_role" {
   }
 }
 
-resource "aws_iam_role" "preprod" {
-  name               = var.preprod.iam_role_name
+resource "aws_iam_role" "shared" {
+  name               = var.shared_iam_role_name
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 
-resource "aws_iam_role_policy_attachment" "preprod_basic_execution" {
-  role       = aws_iam_role.preprod.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-}
-
-resource "aws_iam_role" "prod" {
-  name               = var.prod.iam_role_name
-  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
-}
-
-resource "aws_iam_role_policy_attachment" "prod_basic_execution" {
-  role       = aws_iam_role.prod.name
+resource "aws_iam_role_policy_attachment" "shared_basic_execution" {
+  role       = aws_iam_role.shared.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }

--- a/terraform/lambda-config/iam.tf
+++ b/terraform/lambda-config/iam.tf
@@ -1,0 +1,47 @@
+# IAM execution roles for the Lambdas.
+#
+# The Lambda code only needs the basic execution role (CloudWatch Logs).
+# All external calls are HTTPS (to Domoticz) or MySQL over TCP — neither
+# requires AWS service permissions. If you later add S3/DynamoDB/etc.
+# access, attach additional policies here.
+#
+# For from-scratch deployment, `terraform apply` creates these roles.
+# For an existing setup, import them before apply:
+#
+#   terraform import aws_iam_role.preprod <existing-role-name>
+#   terraform import aws_iam_role.prod    <existing-role-name>
+#
+# (Find existing role names with `aws lambda get-function-configuration
+#  --function-name <fn> --query 'Role' --output text` and strip the ARN
+#  prefix to keep just the role name.)
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "preprod" {
+  name               = var.preprod.iam_role_name
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "preprod_basic_execution" {
+  role       = aws_iam_role.preprod.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role" "prod" {
+  name               = var.prod.iam_role_name
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "prod_basic_execution" {
+  role       = aws_iam_role.prod.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/terraform/lambda-config/main.tf
+++ b/terraform/lambda-config/main.tf
@@ -19,7 +19,18 @@ locals {
     NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS = "true"
   } : {}
 
-  nr_env_vars = merge(local.nr_env_vars_base, local.nr_env_vars_logs)
+  # Optional: override the extension's data-collection wait window.
+  # Set var.nr_data_collection_timeout = "" to leave it unset (use
+  # extension defaults).
+  nr_env_vars_timeout = var.nr_data_collection_timeout != "" ? {
+    NEW_RELIC_DATA_COLLECTION_TIMEOUT = var.nr_data_collection_timeout
+  } : {}
+
+  nr_env_vars = merge(
+    local.nr_env_vars_base,
+    local.nr_env_vars_logs,
+    local.nr_env_vars_timeout,
+  )
 }
 
 # Placeholder zip used to satisfy the aws_lambda_function `filename`

--- a/terraform/lambda-config/main.tf
+++ b/terraform/lambda-config/main.tf
@@ -1,0 +1,39 @@
+# Locals shared across both functions.
+#
+# `nr_env_vars` is merged with each function's `env_vars` map. The
+# secrets (NEW_RELIC_LICENSE_KEY) come from sensitive variables and
+# are stored only in the S3 tfstate (private bucket, gitignored
+# .envrc).
+
+locals {
+  nr_env_vars_base = {
+    NEW_RELIC_LICENSE_KEY     = var.nr_license_key
+    NEW_RELIC_ACCOUNT_ID      = var.nr_account_id
+    NEW_RELIC_LAMBDA_HANDLER  = "index.handler"
+    NEW_RELIC_APM_LAMBDA_MODE = "true"
+  }
+
+  # Optional: forward CloudWatch logs to NR. Off by default — see the
+  # nr_extension_send_function_logs variable.
+  nr_env_vars_logs = var.nr_extension_send_function_logs ? {
+    NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS = "true"
+  } : {}
+
+  nr_env_vars = merge(local.nr_env_vars_base, local.nr_env_vars_logs)
+}
+
+# Placeholder zip used to satisfy the aws_lambda_function `filename`
+# argument. Terraform never deploys this — see lifecycle.ignore_changes
+# on the function resources in functions.tf. The actual function code
+# is shipped by scripts/deploy.sh.
+#
+# Written inside .terraform/ so the generated zip is gitignored via the
+# existing `**/.terraform/` rule (no need to touch .gitignore).
+data "archive_file" "placeholder" {
+  type        = "zip"
+  output_path = "${path.module}/.terraform/placeholder.zip"
+  source {
+    content  = "// placeholder — function code is managed by scripts/deploy.sh"
+    filename = "placeholder.js"
+  }
+}

--- a/terraform/lambda-config/outputs.tf
+++ b/terraform/lambda-config/outputs.tf
@@ -1,0 +1,19 @@
+output "preprod_function_arn" {
+  description = "ARN of the preprod Lambda after Terraform took it over."
+  value       = aws_lambda_function.preprod.arn
+}
+
+output "prod_function_arn" {
+  description = "ARN of the prod Lambda after Terraform took it over."
+  value       = aws_lambda_function.prod.arn
+}
+
+output "preprod_last_modified" {
+  description = "When AWS last updated the preprod function (useful to confirm deploy.sh runs)."
+  value       = aws_lambda_function.preprod.last_modified
+}
+
+output "prod_last_modified" {
+  description = "When AWS last updated the prod function."
+  value       = aws_lambda_function.prod.last_modified
+}

--- a/terraform/lambda-config/providers.tf
+++ b/terraform/lambda-config/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/lambda-config/terraform.tfvars.example
+++ b/terraform/lambda-config/terraform.tfvars.example
@@ -4,14 +4,15 @@
 
 nr_account_id = "7960957"
 
-# For from-scratch deployment, pick canonical role names below — Terraform
-# will create them with the basic Lambda execution policy attached.
-# When adopting existing functions, set these to the existing roles'
-# names and import them first (see README → "Adopt existing functions").
+# Shared IAM execution role name. Both Lambdas reference the same role.
+# For from-scratch deployment, pick a canonical name (e.g. alhau-lambda-execution)
+# — Terraform will create it with the basic Lambda execution policy attached.
+# When adopting an existing setup, set this to the existing role's name
+# and import it first (see README → "Adopt existing functions").
+shared_iam_role_name = "aws-serverless-repository-o-Oauth2SharedLamdbaRole-XXXXXX"
 
 preprod = {
   function_name = "alhau_preprod"
-  iam_role_name = "alhau_preprod-execution"
 
   # FULL current env vars — capture with:
   #   aws lambda get-function-configuration --function-name alhau_preprod \
@@ -41,7 +42,6 @@ preprod = {
 
 prod = {
   function_name = "ludohomekit"
-  iam_role_name = "ludohomekit-execution"
 
   env_vars = {
     INSTANCE_NAME = "prod"

--- a/terraform/lambda-config/terraform.tfvars.example
+++ b/terraform/lambda-config/terraform.tfvars.example
@@ -1,0 +1,50 @@
+# Copy to terraform.tfvars (gitignored) and fill in.
+# Secrets (nr_license_key) should come from TF_VAR_nr_license_key in
+# the parent terraform/.envrc — leave them out of this file.
+
+nr_account_id = "7960957"
+
+# Lookup role ARNs once with:
+#   aws lambda get-function-configuration --function-name alhau_preprod \
+#     --query 'Role' --output text
+
+preprod = {
+  function_name = "alhau_preprod"
+  role_arn      = "arn:aws:iam::242542229507:role/service-role/REPLACE-ME"
+
+  # FULL current env vars — capture with:
+  #   aws lambda get-function-configuration --function-name alhau_preprod \
+  #     --query 'Environment.Variables' --output json
+  env_vars = {
+    INSTANCE_NAME       = "PREPROD"
+    PROD_MODE           = "true"
+    DEBUG               = "prod,stats"
+    DEBUG_HIDE_DATE     = "true"
+    MYSQL_ADDON_HOST    = "REPLACE-ME"
+    MYSQL_ADDON_PORT    = "3306"
+    MYSQL_ADDON_USER    = "REPLACE-ME"
+    MYSQL_ADDON_PASSWORD = "REPLACE-ME"
+    MYSQL_ADDON_DB      = "REPLACE-ME"
+    CRYPTOPASS          = "REPLACE-ME"
+    DOMOTICZ_API_HOST   = "REPLACE-ME"
+    DOMOTICZ_API_PORT   = "REPLACE-ME"
+    DOMOTICZ_API_LOGIN  = "REPLACE-ME"
+    DOMOTICZ_API_PASSWORD = "REPLACE-ME"
+    METRICS_HOST        = "REPLACE-ME"
+    METRICS_PORT        = "REPLACE-ME"
+    METRICS_UDP_PORT    = "REPLACE-ME"
+    # NEW_RELIC_* vars below are managed by Terraform via main.tf locals —
+    # do not duplicate them here.
+  }
+}
+
+prod = {
+  function_name = "ludohomekit"
+  role_arn      = "arn:aws:iam::242542229507:role/service-role/REPLACE-ME"
+
+  env_vars = {
+    INSTANCE_NAME       = "prod"
+    PROD_MODE           = "true"
+    # ... same shape as preprod above
+  }
+}

--- a/terraform/lambda-config/terraform.tfvars.example
+++ b/terraform/lambda-config/terraform.tfvars.example
@@ -4,13 +4,14 @@
 
 nr_account_id = "7960957"
 
-# Lookup role ARNs once with:
-#   aws lambda get-function-configuration --function-name alhau_preprod \
-#     --query 'Role' --output text
+# For from-scratch deployment, pick canonical role names below — Terraform
+# will create them with the basic Lambda execution policy attached.
+# When adopting existing functions, set these to the existing roles'
+# names and import them first (see README → "Adopt existing functions").
 
 preprod = {
   function_name = "alhau_preprod"
-  role_arn      = "arn:aws:iam::242542229507:role/service-role/REPLACE-ME"
+  iam_role_name = "alhau_preprod-execution"
 
   # FULL current env vars — capture with:
   #   aws lambda get-function-configuration --function-name alhau_preprod \
@@ -40,11 +41,11 @@ preprod = {
 
 prod = {
   function_name = "ludohomekit"
-  role_arn      = "arn:aws:iam::242542229507:role/service-role/REPLACE-ME"
+  iam_role_name = "ludohomekit-execution"
 
   env_vars = {
-    INSTANCE_NAME       = "prod"
-    PROD_MODE           = "true"
+    INSTANCE_NAME = "prod"
+    PROD_MODE     = "true"
     # ... same shape as preprod above
   }
 }

--- a/terraform/lambda-config/variables.tf
+++ b/terraform/lambda-config/variables.tf
@@ -56,16 +56,27 @@ EOT
 
 # --- Per-function configuration --------------------------------------
 
+variable "shared_iam_role_name" {
+  description = <<EOT
+Name of the IAM execution role shared by both Lambdas (preprod and
+prod). Terraform creates this role from-scratch (with the basic Lambda
+execution policy attached); when adopting an existing setup, set this
+to the existing shared role's name and `terraform import` it before
+applying — see README.
+
+We model this as a single shared role because the two Lambdas in this
+project use the same execution role. If you later need distinct roles
+per environment, split this into two `aws_iam_role` resources in
+iam.tf and reference each from the matching `aws_lambda_function`.
+EOT
+  type        = string
+}
+
 variable "preprod" {
   description = <<EOT
 Configuration for the preprod Lambda.
 
 `function_name` is the AWS Lambda function name.
-
-`iam_role_name` is the IAM execution role name. Terraform creates it
-from scratch (with the basic Lambda execution policy attached). When
-adopting an existing function, set this to the existing role's name
-and `terraform import` the role before applying — see README.
 
 `env_vars` is the FULL map of application env vars currently set on the
 function (DOMOTICZ_*, MYSQL_*, CRYPTOPASS, etc.). Terraform will merge
@@ -75,7 +86,6 @@ the one-shot capture command.
 EOT
   type = object({
     function_name = string
-    iam_role_name = string
     env_vars      = map(string)
   })
   sensitive = true
@@ -85,7 +95,6 @@ variable "prod" {
   description = "Same shape as `preprod`, but for the prod Lambda (ludohomekit)."
   type = object({
     function_name = string
-    iam_role_name = string
     env_vars      = map(string)
   })
   sensitive = true

--- a/terraform/lambda-config/variables.tf
+++ b/terraform/lambda-config/variables.tf
@@ -42,6 +42,18 @@ EOT
   default     = false
 }
 
+variable "nr_data_collection_timeout" {
+  description = <<EOT
+How long the NR Lambda Extension waits for agent telemetry after the
+handler returns before flushing. Default 30s — covers slow Alexa
+requests (e.g. Domoticz timing out on flaky home networks) without
+delaying the user-visible response. Set to "" to use the extension's
+own default (~100ms in Standard mode).
+EOT
+  type        = string
+  default     = "30s"
+}
+
 # --- Per-function configuration --------------------------------------
 
 variable "preprod" {

--- a/terraform/lambda-config/variables.tf
+++ b/terraform/lambda-config/variables.tf
@@ -1,0 +1,76 @@
+variable "aws_region" {
+  description = "AWS region where the Lambdas live."
+  type        = string
+  default     = "eu-west-1"
+}
+
+# --- New Relic --------------------------------------------------------
+
+variable "nr_lambda_layer_arn" {
+  description = <<EOT
+ARN of the New Relic Lambda layer. Default targets Node.js 24 in eu-west-1.
+Bump the version (last segment) as new layers are published — see
+https://layers.newrelic-external.com.
+EOT
+  type        = string
+  default     = "arn:aws:lambda:eu-west-1:451483290750:layer:NewRelicNodeJS24X:27"
+}
+
+variable "nr_license_key" {
+  description = <<EOT
+New Relic License key (a.k.a. Ingest key). EU keys start with `eu01xx`.
+Find it at https://one.eu.newrelic.com/api-keys (type "License key").
+This is a secret — set via TF_VAR_nr_license_key in .envrc, never commit.
+EOT
+  type        = string
+  sensitive   = true
+}
+
+variable "nr_account_id" {
+  description = "New Relic account ID. Same value as terraform/dashboard/'s nr_account_id."
+  type        = string
+}
+
+variable "nr_extension_send_function_logs" {
+  description = <<EOT
+When true, the NR Lambda Extension forwards CloudWatch Lambda logs to
+NR (so they appear in `FROM Log WHERE entity.name = ...`). False keeps
+logs out of NR ingest — recommended on the free tier given verbose
+prodLogger output.
+EOT
+  type        = bool
+  default     = false
+}
+
+# --- Per-function configuration --------------------------------------
+
+variable "preprod" {
+  description = <<EOT
+Configuration for the preprod Lambda.
+
+`function_name` and `role_arn` mirror the live AWS values (look them up
+with `aws lambda get-function-configuration --function-name <name>`).
+
+`env_vars` is the FULL map of application env vars currently set on the
+function (DOMOTICZ_*, MYSQL_*, CRYPTOPASS, etc.). Terraform will merge
+this with the NR-specific env vars from main.tf — anything missing here
+will be REMOVED from the live function when apply runs. See README for
+the one-shot capture command.
+EOT
+  type = object({
+    function_name = string
+    role_arn      = string
+    env_vars      = map(string)
+  })
+  sensitive = true
+}
+
+variable "prod" {
+  description = "Same shape as `preprod`, but for the prod Lambda (ludohomekit)."
+  type = object({
+    function_name = string
+    role_arn      = string
+    env_vars      = map(string)
+  })
+  sensitive = true
+}

--- a/terraform/lambda-config/variables.tf
+++ b/terraform/lambda-config/variables.tf
@@ -48,8 +48,12 @@ variable "preprod" {
   description = <<EOT
 Configuration for the preprod Lambda.
 
-`function_name` and `role_arn` mirror the live AWS values (look them up
-with `aws lambda get-function-configuration --function-name <name>`).
+`function_name` is the AWS Lambda function name.
+
+`iam_role_name` is the IAM execution role name. Terraform creates it
+from scratch (with the basic Lambda execution policy attached). When
+adopting an existing function, set this to the existing role's name
+and `terraform import` the role before applying — see README.
 
 `env_vars` is the FULL map of application env vars currently set on the
 function (DOMOTICZ_*, MYSQL_*, CRYPTOPASS, etc.). Terraform will merge
@@ -59,7 +63,7 @@ the one-shot capture command.
 EOT
   type = object({
     function_name = string
-    role_arn      = string
+    iam_role_name = string
     env_vars      = map(string)
   })
   sensitive = true
@@ -69,7 +73,7 @@ variable "prod" {
   description = "Same shape as `preprod`, but for the prod Lambda (ludohomekit)."
   type = object({
     function_name = string
-    role_arn      = string
+    iam_role_name = string
     env_vars      = map(string)
   })
   sensitive = true

--- a/terraform/lambda-config/variables.tf
+++ b/terraform/lambda-config/variables.tf
@@ -56,6 +56,28 @@ EOT
 
 # --- Per-function configuration --------------------------------------
 
+variable "lambda_timeout" {
+  description = <<EOT
+Per-invocation timeout (seconds) for both Lambdas. Alexa demands a
+response within 8s for a good user experience and absolute max ~8s
+before the skill fails — 30s is a generous buffer for slow Domoticz
+hops, async DB lookups, etc. Lambda's hard max is 900s.
+EOT
+  type        = number
+  default     = 30
+}
+
+variable "lambda_memory_size" {
+  description = <<EOT
+Memory allocation (MB) for both Lambdas. 128 MB is sufficient for the
+current workload (Node 24 + NR Lambda layer fit in this with ~10 MB
+headroom). Lambda scales CPU proportionally to memory — bump to 256
+or 512 if you notice latency creeping up at cold starts.
+EOT
+  type        = number
+  default     = 128
+}
+
 variable "shared_iam_role_name" {
   description = <<EOT
 Name of the IAM execution role shared by both Lambdas (preprod and

--- a/terraform/lambda-config/versions.tf
+++ b/terraform/lambda-config/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.50"
+    }
+    # archive provider is used to materialise a placeholder zip for the
+    # aws_lambda_function `filename` argument. The actual function code
+    # is deployed by scripts/deploy.sh — see lifecycle.ignore_changes in
+    # functions.tf.
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}

--- a/terraform/lambda-config/versions.tf
+++ b/terraform/lambda-config/versions.tf
@@ -3,8 +3,11 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.50"
+      source = "hashicorp/aws"
+      # Need >= 5.80 for nodejs24.x runtime validation (latest runtimes
+      # are added in minor releases). Allowing 6.x too, which is mature
+      # as of 2026.
+      version = ">= 5.80, < 7.0"
     }
     # archive provider is used to materialise a placeholder zip for the
     # aws_lambda_function `filename` argument. The actual function code


### PR DESCRIPTION
## Summary

Adds a new Terraform module `terraform/lambda-config/` that owns the **runtime configuration** of both Lambdas (`alhau_preprod` + `ludohomekit`). Replaces the manual AWS-console setup we documented for the New Relic Lambda Layer wiring (handler, layer, env vars).

## Why

Up to now, the NR Lambda Layer setup (handler = `newrelic-lambda-wrapper.handler`, layer attached, env vars `NEW_RELIC_LICENSE_KEY` / `NEW_RELIC_ACCOUNT_ID` / `NEW_RELIC_LAMBDA_HANDLER` / `NEW_RELIC_APM_LAMBDA_MODE` / etc.) was set by hand in the AWS console — fragile, not reproducible, easy to undo by accident. This module captures all of that as code in the same flavor as `terraform/dashboard/`.

## Boundaries

| Owned by Terraform | Owned by `scripts/deploy.sh` |
|---|---|
| `handler` = `newrelic-lambda-wrapper.handler` | The function code zip |
| `runtime` = `nodejs24.x` | |
| `layers` (NR Lambda Layer) | |
| `environment.variables` (full map: app vars + NR vars) | |

`lifecycle.ignore_changes` on `filename`, `s3_bucket`, `s3_key`, `s3_object_version`, `source_code_hash`, `last_modified` keeps Terraform out of the code-deploy pathway, so `deploy.sh` and `terraform apply` touch disjoint attributes.

## Files

```
terraform/lambda-config/
├── README.md               # full bootstrap + usage guide
├── backend.tf              # S3 backend (same bucket, dedicated key)
├── functions.tf            # the 2 aws_lambda_function resources
├── main.tf                 # locals (NR env vars) + placeholder zip
├── outputs.tf
├── providers.tf
├── terraform.tfvars.example
├── variables.tf
└── versions.tf
```

## How to roll this out (one-shot per function)

1. Capture current values: role ARN + every existing env var (commands in README).
2. Fill `terraform.tfvars` from the example (gitignored — contains DB passwords etc.).
3. Export `TF_VAR_nr_license_key` in `terraform/.envrc`.
4. `terraform init` then `terraform import aws_lambda_function.preprod alhau_preprod` (and same for prod).
5. `terraform plan` — should show only the NR-related changes (layer add, env var adds, handler swap).
6. `terraform apply`.

After this, the manual console wiring is reproducible, drift-detectable, and version-controlled.

## Secrets handling

- `nr_license_key` → sensitive Terraform variable, set via `TF_VAR_*` in `.envrc`.
- App secrets (DB password, CRYPTOPASS, Domoticz creds) → in `terraform.tfvars` (gitignored, lives only locally + in the encrypted S3 tfstate).

This is the lightweight option appropriate for a personal project. Moving secrets to AWS Secrets Manager is possible later without disrupting this structure.

## Test plan

- [ ] On the user's machine: capture current env vars + role ARN per function
- [ ] Fill `terraform.tfvars` + set `TF_VAR_nr_license_key`
- [ ] `terraform init` succeeds
- [ ] `terraform import` succeeds for both functions
- [ ] `terraform plan` shows only NR-related diffs (no app env vars removed)
- [ ] `terraform apply` succeeds
- [ ] Invoke Alexa → metrics continue to flow (no regression)
- [ ] Next `scripts/deploy.sh` run unaffected — code zip still updates, Terraform plan stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)