### PR TITLE
fix(dashboard): Logs page uses faas.name (not entity.name) and uppercase ERROR

### DIFF
--- a/terraform/dashboard/modules/alhau-dashboard/pages.tf
+++ b/terraform/dashboard/modules/alhau-dashboard/pages.tf
@@ -540,7 +540,7 @@ resource "newrelic_one_dashboard" "alhau" {
 
       nrql_query {
         account_id = var.account_id
-        query      = "FROM Log SELECT count(*) WHERE entity.name = {{ instance }} FACET level TIMESERIES"
+        query      = "FROM Log SELECT count(*) WHERE faas.name = {{ instance }} FACET level TIMESERIES"
       }
 
       legend_enabled = true
@@ -555,7 +555,7 @@ resource "newrelic_one_dashboard" "alhau" {
 
       nrql_query {
         account_id = var.account_id
-        query      = "FROM Log SELECT timestamp, message, level WHERE entity.name = {{ instance }} AND level = 'error' SINCE 1 day ago LIMIT 100"
+        query      = "FROM Log SELECT timestamp, message, level WHERE faas.name = {{ instance }} AND level = 'ERROR' SINCE 1 day ago LIMIT 100"
       }
     }
 
@@ -568,7 +568,7 @@ resource "newrelic_one_dashboard" "alhau" {
 
       nrql_query {
         account_id = var.account_id
-        query      = "FROM Log SELECT timestamp, message, level WHERE entity.name = {{ instance }} SINCE 1 hour ago LIMIT 200"
+        query      = "FROM Log SELECT timestamp, message, level WHERE faas.name = {{ instance }} SINCE 1 hour ago LIMIT 200"
       }
     }
   }


### PR DESCRIPTION
## Summary

The three widgets on Page 4 "Logs" of the NR dashboard came up empty because the filter targeted the wrong field, and the ERROR-level filter used the wrong case.

## What was wrong

NR's Lambda integration writes Log records with `faas.name` (the OpenTelemetry semantic-convention attribute for serverless function name), **not** `entity.name`. Sample of an actual Log record from `ludohomekit`:

```
faas.name: ludohomekit         ← the function name is HERE
entity.guid: Nzk2MDk1N3...
entity.guids: Nzk2MDk1N3...
(no entity.name field)
```

So `WHERE entity.name = {{ instance }}` matched nothing and the widgets showed `No data available`.

Additionally, NRQL string equality is case-sensitive and the agent emits levels in **uppercase** (`ERROR`, `INFO`, `DEBUG`). The "Recent ERROR logs" widget's `level = 'error'` (lowercase) didn't match.

## What changed

In `terraform/dashboard/modules/alhau-dashboard/pages.tf` Page 4 widgets only:

- `entity.name = {{ instance }}` → `faas.name = {{ instance }}` (3 widgets)
- `level = 'error'` → `level = 'ERROR'` (1 widget)

## Test plan

- [ ] `terraform apply` on the dashboard module
- [ ] Reload the dashboard, switch the env dropdown to preprod
- [ ] The 3 Page 4 "Logs" widgets now populate (log volume by level, recent errors, recent logs)
- [ ] After a real Domoticz issue, "Recent ERROR logs" surfaces the `Invoke Error` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)