### PR TITLE
feat(terraform): manage NR alerts (policy + conditions + email workflow)

### DIFF
--- a/terraform/alerts/README.md
+++ b/terraform/alerts/README.md
@@ -1,0 +1,105 @@
+# Terraform — New Relic alerts
+
+Manages alert conditions + notification workflow for the ALHAU project.
+Three conditions today:
+
+| Condition | Scope | Threshold | Trigger |
+|---|---|---|---|
+| `prod_throughput_signal_loss` | prod only | `< 0.1 req/min` | Mostly via `expiration` — opens incident after 8h of no signal |
+| `high_response_time` | prod + preprod (FACETed) | `> 3000 ms` | 5 min sustained |
+| `high_error_percentage` | prod + preprod (FACETed) | `> 5 %` | 5 min sustained |
+
+All three live under a single policy `ALHAU — Alexa HomeKit`. A workflow
+routes incidents to one email destination (`var.notification_email`).
+
+## Prerequisites
+
+- Terraform >= 1.10
+- The `alhau-tfstate` S3 bucket from `terraform/bootstrap/`
+- `terraform/.envrc` sourced with `NEW_RELIC_API_KEY` + `TF_VAR_nr_account_id`
+  + `TF_VAR_notification_email`
+
+## Bootstrap
+
+```bash
+cd terraform/alerts
+
+# Set the destination email (in terraform/.envrc, NOT committed):
+echo 'export TF_VAR_notification_email="you@example.com"' >> ../.envrc
+source ../.envrc
+
+terraform init
+terraform plan        # review conditions
+terraform apply
+```
+
+## Clean up the NR auto-defaults
+
+When the NR Lambda layer first reported telemetry, NR auto-created a
+default policy with conditions that overlap what we manage here. After
+this module's `apply`, **delete the auto-defaults** to avoid two
+notifications per incident:
+
+1. NR UI → **Alerts** → **Alert conditions**
+2. Filter by `appName = ludohomekit` or `alhau_preprod`
+3. Find conditions on policies you didn't create (typically named
+   "Low throughput", "High response time", "Apdex below threshold")
+4. Disable or delete them
+
+The conditions inside our `ALHAU — Alexa HomeKit` policy are the
+keepers.
+
+## Tweaking thresholds
+
+Pick a parameter in `variables.tf` or inline in `conditions.tf` and
+edit. Examples:
+
+- **Less sensitive throughput** → bump `signal_loss_duration_seconds`
+  to 43200 (12h) or 86400 (24h)
+- **Tighter response time SLO** → change the `3000` to `2000` in
+  `conditions.tf`
+- **Looser error rate** → change `5` to `10` in `conditions.tf`
+
+After edit: `terraform apply`.
+
+## Disable notifications temporarily
+
+Set `TF_VAR_notification_email=""` then `terraform apply`. The
+destination, channel and workflow are torn down; conditions still fire
+internally (visible in NR UI under Alerts → Issues) but nothing reaches
+your inbox.
+
+## Should I manage alerts for ALL my projects in one place?
+
+You have multiple NR-monitored projects (this Alexa Lambda, the Kimsufi
+apps, the Coolify VPS). Two patterns:
+
+| | Per-project (recommended) | Centralised |
+|---|---|---|
+| Where the TF lives | In each project's repo | In a separate `nr-monitoring/` repo |
+| State file | One per project (different S3 keys, same bucket) | One global state |
+| Pros | Monitoring colocated with code, separate review cycles, can delete a project cleanly | Single source of truth for alert patterns |
+| Cons | Need to copy similar files across projects | Touching prod changes risks affecting other projects |
+
+For your situation (3 distinct projects, ~personal scale), **per-project
+is the better default**. Each project repo gets its own `terraform/alerts/`
+module pointing to the same NR account. The provider config is identical;
+only the conditions differ.
+
+If you find yourself copy-pasting the same conditions across 3 repos,
+that's the moment to extract a Terraform module (a published one, or a
+local module you `git submodule` into each project). Premature
+otherwise.
+
+## Architecture
+
+```
+terraform/
+├── bootstrap/           # local state — creates the S3 bucket
+├── dashboard/           # S3-backed — NR dashboard
+├── lambda-config/       # S3-backed — Lambda runtime config
+└── alerts/              # S3-backed — alert conditions + workflow  ← you are here
+```
+
+All four modules share the same S3 bucket (`alhau-tfstate`) under
+distinct state keys.

--- a/terraform/alerts/backend.tf
+++ b/terraform/alerts/backend.tf
@@ -1,0 +1,11 @@
+# Remote state in the same S3 bucket as the other modules, under a
+# dedicated key so the alert state stays isolated.
+terraform {
+  backend "s3" {
+    bucket       = "alhau-tfstate"
+    key          = "alerts/terraform.tfstate"
+    region       = "eu-west-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/terraform/alerts/conditions.tf
+++ b/terraform/alerts/conditions.tf
@@ -1,0 +1,106 @@
+# Alert conditions for the Alhau project.
+#
+# Three conditions covering what the NR auto-defaults provide PLUS the
+# prod-only throughput watcher with a tolerant signal-loss window.
+#
+# ─────────────────────────────────────────────────────────────────────
+# Important — deduplicating with NR's auto-created defaults
+# ─────────────────────────────────────────────────────────────────────
+# When the NR Lambda layer first reports telemetry, NR auto-creates
+# default conditions ("High response time", "High error percentage",
+# "Low throughput") on a synthetic policy. They duplicate what's
+# defined here. After `terraform apply`, delete those auto-defaults
+# in the NR UI (Alerts → Alert conditions → filter by appName) to
+# avoid getting two notifications for the same incident.
+
+# ─────────────────────────────────────────────────────────────────────
+# 1. Throughput — prod ONLY, signal-loss based
+# ─────────────────────────────────────────────────────────────────────
+# The threshold is set very low (below 0.1) so it almost never fires
+# on a regular dip. The real trigger is `expiration` — if the signal
+# goes silent for var.signal_loss_duration_seconds (default 8h), an
+# incident is opened. That's the "the Lambda is dead" signal.
+resource "newrelic_nrql_alert_condition" "prod_throughput_signal_loss" {
+  account_id                   = var.nr_account_id
+  policy_id                    = newrelic_alert_policy.alhau.id
+  type                         = "static"
+  name                         = "Prod — throughput signal lost (> ${var.signal_loss_duration_seconds / 60} min)"
+  enabled                      = true
+  violation_time_limit_seconds = 86400
+  aggregation_method           = "EVENT_FLOW"
+  aggregation_delay            = 60
+
+  nrql {
+    query = "SELECT average(`newrelic.goldenmetrics.apm.application.throughput`) FROM Metric WHERE appName = '${var.prod_app_name}'"
+  }
+
+  critical {
+    operator              = "below"
+    threshold             = 0.1
+    threshold_duration    = 300
+    threshold_occurrences = "ALL"
+  }
+
+  expiration {
+    open_violation_on_expiration   = true
+    expiration_duration            = var.signal_loss_duration_seconds
+    close_violations_on_expiration = false
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# 2. High Response Time — both envs (replaces NR's "High Response Time")
+# ─────────────────────────────────────────────────────────────────────
+# 3 seconds is the practical UX limit for Alexa skills — beyond that
+# users get the "skill having trouble" prompt. FACET appName so prod
+# and preprod fire separate incidents (you can mute one without
+# touching the other).
+resource "newrelic_nrql_alert_condition" "high_response_time" {
+  account_id                   = var.nr_account_id
+  policy_id                    = newrelic_alert_policy.alhau.id
+  type                         = "static"
+  name                         = "High response time (> 3s)"
+  enabled                      = true
+  violation_time_limit_seconds = 86400
+  aggregation_method           = "EVENT_FLOW"
+  aggregation_delay            = 60
+
+  nrql {
+    query = "SELECT average(`newrelic.goldenmetrics.apm.application.responseTimeMs`) FROM Metric WHERE appName IN ('${var.prod_app_name}', '${var.preprod_app_name}') FACET appName"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = 3000
+    threshold_duration    = 300
+    threshold_occurrences = "ALL"
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# 3. High Error Percentage — both envs
+# ─────────────────────────────────────────────────────────────────────
+# Lambda invocations that error out (including Domoticz socket hang ups
+# in pratique). 5% is a reasonable bar — below that, transient network
+# glitches are normal; above, something systemic is broken.
+resource "newrelic_nrql_alert_condition" "high_error_percentage" {
+  account_id                   = var.nr_account_id
+  policy_id                    = newrelic_alert_policy.alhau.id
+  type                         = "static"
+  name                         = "High error percentage (> 5%)"
+  enabled                      = true
+  violation_time_limit_seconds = 86400
+  aggregation_method           = "EVENT_FLOW"
+  aggregation_delay            = 60
+
+  nrql {
+    query = "SELECT percentage(count(*), WHERE error IS true) FROM Transaction WHERE appName IN ('${var.prod_app_name}', '${var.preprod_app_name}') FACET appName"
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = 5
+    threshold_duration    = 300
+    threshold_occurrences = "ALL"
+  }
+}

--- a/terraform/alerts/main.tf
+++ b/terraform/alerts/main.tf
@@ -1,0 +1,8 @@
+# One alert policy that groups every condition for this project.
+# A single policy means a single workflow handles routing — simpler
+# than splitting prod/preprod into separate policies.
+resource "newrelic_alert_policy" "alhau" {
+  account_id          = var.nr_account_id
+  name                = "ALHAU — Alexa HomeKit"
+  incident_preference = "PER_CONDITION_AND_TARGET"
+}

--- a/terraform/alerts/notifications.tf
+++ b/terraform/alerts/notifications.tf
@@ -1,0 +1,58 @@
+# Notification pipeline: destination → channel → workflow.
+# The whole chain is only created if notification_email is provided
+# (count = 0 disables the resource cleanly).
+
+resource "newrelic_notification_destination" "email" {
+  count      = var.notification_email == "" ? 0 : 1
+  account_id = var.nr_account_id
+  name       = "ALHAU — email destination"
+  type       = "EMAIL"
+
+  property {
+    key   = "email"
+    value = var.notification_email
+  }
+}
+
+resource "newrelic_notification_channel" "email" {
+  count          = var.notification_email == "" ? 0 : 1
+  account_id     = var.nr_account_id
+  name           = "ALHAU — email channel"
+  type           = "EMAIL"
+  destination_id = newrelic_notification_destination.email[0].id
+  product        = "IINT"
+
+  property {
+    key   = "subject"
+    value = "{{ issueTitle }}"
+  }
+}
+
+# The workflow ties the alert policy to the notification channel.
+# muting_rules_handling = NOTIFY_ALL_ISSUES means muting rules in NR UI
+# are ignored — flip to DONT_NOTIFY_FULLY_MUTED_ISSUES if you start
+# using muting windows (e.g. silent during a known maintenance).
+resource "newrelic_workflow" "alhau" {
+  count                 = var.notification_email == "" ? 0 : 1
+  account_id            = var.nr_account_id
+  name                  = "ALHAU — alert workflow"
+  enrichments_enabled   = true
+  destinations_enabled  = true
+  workflow_enabled      = true
+  muting_rules_handling = "NOTIFY_ALL_ISSUES"
+
+  issues_filter {
+    name = "policyId filter"
+    type = "FILTER"
+
+    predicate {
+      attribute = "labels.policyIds"
+      operator  = "EXACTLY_MATCHES"
+      values    = [newrelic_alert_policy.alhau.id]
+    }
+  }
+
+  destination {
+    channel_id = newrelic_notification_channel.email[0].id
+  }
+}

--- a/terraform/alerts/outputs.tf
+++ b/terraform/alerts/outputs.tf
@@ -1,0 +1,9 @@
+output "policy_id" {
+  description = "ID of the alert policy — useful to attach more conditions externally."
+  value       = newrelic_alert_policy.alhau.id
+}
+
+output "policy_name" {
+  description = "Friendly name of the alert policy."
+  value       = newrelic_alert_policy.alhau.name
+}

--- a/terraform/alerts/providers.tf
+++ b/terraform/alerts/providers.tf
@@ -1,0 +1,4 @@
+provider "newrelic" {
+  account_id = var.nr_account_id
+  region     = var.nr_region
+}

--- a/terraform/alerts/variables.tf
+++ b/terraform/alerts/variables.tf
@@ -1,0 +1,44 @@
+variable "nr_account_id" {
+  description = "New Relic account ID (e.g. 7960957)."
+  type        = string
+}
+
+variable "nr_region" {
+  description = "New Relic region — EU or US."
+  type        = string
+  default     = "EU"
+}
+
+variable "prod_app_name" {
+  description = "appName of the prod Lambda in New Relic (matches NR Lambda layer naming)."
+  type        = string
+  default     = "ludohomekit"
+}
+
+variable "preprod_app_name" {
+  description = "appName of the preprod Lambda in New Relic."
+  type        = string
+  default     = "alhau_preprod"
+}
+
+variable "notification_email" {
+  description = <<EOT
+Email address where alert notifications are sent. Set via
+TF_VAR_notification_email in .envrc. Empty disables the email channel
+(conditions still exist but no notifications go out — useful while
+tuning thresholds).
+EOT
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "signal_loss_duration_seconds" {
+  description = <<EOT
+How long the throughput signal must be absent before NR opens an
+incident. Default 28800s = 8h, large enough to absorb the natural
+quiet periods of a public Alexa skill (nights, low-traffic days).
+EOT
+  type        = number
+  default     = 28800
+}

--- a/terraform/alerts/versions.tf
+++ b/terraform/alerts/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "~> 3.40"
+    }
+  }
+}


### PR DESCRIPTION
## What

Introduces a new `terraform/alerts/` module that codifies the project's New Relic alerting setup:

- One alert policy: **`ALHAU — Alexa HomeKit`**
- Three NRQL conditions
- An optional email notification pipeline (destination → channel → workflow)

State lives in the existing `alhau-tfstate` S3 bucket under key `alerts/terraform.tfstate`.

## Conditions

| # | Condition | Scope | Threshold | Real trigger |
|---|---|---|---|---|
| 1 | `prod_throughput_signal_loss` | prod only (`ludohomekit`) | `< 0.1 req/min` | `expiration` — opens incident after `var.signal_loss_duration_seconds` (default **8h = 28800s**) with no signal |
| 2 | `high_response_time` | prod + preprod (FACET) | `> 3000 ms` | 5 min sustained |
| 3 | `high_error_percentage` | prod + preprod (FACET) | `> 5 %` | 5 min sustained |

Threshold #1 is intentionally trivial (0.1) so it never fires on a normal traffic dip — the meat of that alert is the `expiration` block. A natural Alexa-skill silence overnight (a few hours) won't trigger it; 8 hours of total silence will.

## Notification routing

- Email destination + channel + workflow created only when `TF_VAR_notification_email` is set.
- Empty string disables the whole pipeline (conditions still exist and you can see incidents in NR's "Issues" tab — useful while tuning).
- Subject line: `{{ issueTitle }}` (NR's templating).

## Coverage vs the NR auto-defaults

The NR Lambda layer auto-created similar default conditions on a synthetic policy when telemetry started flowing. After merging this PR + `terraform apply`, **delete the NR auto-defaults** in the UI (Alerts → Alert conditions → filter by `appName`) to avoid two notifications per incident. README documents the steps.

## CPU intentionally omitted

NR has a "High CPU" default for the Infrastructure agent, not for Lambdas. There's no useful CPU metric exposed for AWS Lambda — the closest capacity signal is **handler duration breakdown** (External / DB / Handler share), already on the dashboard. Adding a CPU alert here would be cargo culted from the EC2/server world.

## Should I manage alerts for ALL my projects in one Terraform?

Documented in the README. TL;DR: **per-project** (this module per repo) is the better default. Each project repo keeps its own monitoring colocated with the code, same NR account, separate state files in the same bucket. Only extract into a shared module when copy-paste becomes painful.

## Test plan

- [ ] Set `TF_VAR_notification_email` in `terraform/.envrc`
- [ ] `terraform init && terraform plan` from `terraform/alerts/` — review proposed resources
- [ ] `terraform apply`
- [ ] In NR UI → Alerts → Policies → confirm `ALHAU — Alexa HomeKit` exists with 3 conditions
- [ ] Delete the NR auto-default conditions on `alhau_preprod` / `ludohomekit` to avoid duplicates
- [ ] Trigger a test invocation that breaks (or just wait 8h+ of silence on prod) — confirm the right alert fires and an email arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)